### PR TITLE
Fixed calling the wrong function in csv ostream

### DIFF
--- a/include/text/csv/rows.hpp
+++ b/include/text/csv/rows.hpp
@@ -292,7 +292,7 @@ basic_csv_ostream<Char, Traits> &operator<<(
     for (std::size_t i = 0, n = row.size(); i < n; ++i) {
         os << row[i];
     }
-    os.next_line();
+    os.end_line();
     return os;
 }
 


### PR DESCRIPTION
The next_line() function don't existing in basic_csv_ostream.